### PR TITLE
fixed function "splitCharByte"  use char[4] to calculate char[8]

### DIFF
--- a/BitPermutationFunctions.c
+++ b/BitPermutationFunctions.c
@@ -578,12 +578,15 @@ void splitCharByte(char* input,char* side1,char* side2) {
 
     int i,j,num1,num2;
 
+    char side1_1[8] ={0};
+    char side2_2[8] ={0};
+
     for(i = 0; i < 8; i++) {
   
      for(j = 0; j <8; j++) {
   
-     side1[i] ^= (-(0) ^ side1[i]) & (1<<j);
-     side2[i] ^= (-(0) ^ side2[i]) & (1<<j);
+     side1_1[i] ^= (-(0) ^ side1_1[i]) & (1<<j);
+     side2_2[i] ^= (-(0) ^ side2_2[i]) & (1<<j);
      }
  }
 
@@ -591,12 +594,14 @@ void splitCharByte(char* input,char* side1,char* side2) {
  	for( i = 7; i >= 0; i--) {
 
 	 	num1 = (input[j] >> i) & 0x01;
-                side1[j] ^= (-(num1) ^ side1[j]) & (1<<i);
+                side1_1[j] ^= (-(num1) ^ side1_1[j]) & (1<<i);
 
                 num2 = (input[j+4] >> i) & 0x01;
-                side2[j] ^= (-(num2) ^ side2[j+4]) & (1<<i);
+                side2_2[j] ^= (-(num2) ^ side2_2[j+4]) & (1<<i);
  	}
   }
+  memcpy(side1,side1_1, 4 );
+  memcpy(side2,side2_2,4);
 
 
 }

--- a/BitPermutationFunctions.h
+++ b/BitPermutationFunctions.h
@@ -1,5 +1,9 @@
 #ifndef BITPERMUTATIONFUNCTIONS_H
 #define BITPERMUTATIONFUNCTIONS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
 /*        INITIAL PERMUTATION  */
 void initialPermutation(char* message,char* ip);
@@ -26,5 +30,8 @@ void shiftPBoxOutput(char* message);
 /*      Final Permutation     */
 void finalPermutation(char* message,char* ip);
 void flipSplitBytes(char* output,char* R,char* L);
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/CBCDESDecryption.h
+++ b/CBCDESDecryption.h
@@ -1,8 +1,15 @@
 #ifndef CBCDESDECRYPTION_H
 #define CBCDESDECRYPTION_H
 
-void CBC_DESDecryption(char *input,char* inputKey,char* iv,int size);
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void CBC_DESDecryption(char *input,char* inputKey,char* iv,int size);
+#ifdef __cplusplus
+}
+#endif
 #endif
 
 

--- a/CBCDESEncryption.h
+++ b/CBCDESEncryption.h
@@ -1,7 +1,14 @@
 #ifndef CBCDESENCRYPTION_H
 #define CBCDESENCRYPTION_H
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void CBC_DESEncryption(char *input,char* inputKey,char* iv,int size);
 void TripleCBC_DESEncryption(char* input,char* inputKey,char* iv,int size);
-
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/DESDecrypt.h
+++ b/DESDecrypt.h
@@ -1,6 +1,15 @@
 #ifndef DESDECRYPT_H
 #define DESDECRYPT_H
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void DESDecryption(char *input,char* inputKey,int size);
 void desDecryptionPer64(char* message,char* key);
 void desDecryptionPer64_return(char* message,char* key,char* plaintext);
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/DESEncrypt.c
+++ b/DESEncrypt.c
@@ -144,7 +144,7 @@ void desEncryptionPer64_return(char* message,char* key,char* ciphertext){
  flipSplitBytes(roundOutput,subR[16],subL[16]); // swap R and L
  finalPermutation(roundOutput,finalOutput);// final permutation
  //printCharHex(finalOutput);
- fwrite(finalOutput,sizeof(char),8,stdout);
+ //fwrite(finalOutput,sizeof(char),8,stdout);
  memcpy(ciphertext,finalOutput,8);
 
 }

--- a/DESEncrypt.h
+++ b/DESEncrypt.h
@@ -1,6 +1,14 @@
 #ifndef DESENCRYPT_H
 #define DESENCRYPT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void DESEncryption(char *input,char* inputKey);
 void desEncryptionPer64(char* message,char* key);
 void desEncryptionPer64_return(char* message,char* key,char* ciphertext);
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/DataPrint.h
+++ b/DataPrint.h
@@ -1,7 +1,16 @@
 #ifndef DATAPRINT_H
 #define DATAPRINT_H
 
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void printCharBinary(char* message);
 void printCharHex(char* message);
 void printIntBinary(int message);
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/FileReader.h
+++ b/FileReader.h
@@ -1,6 +1,13 @@
 #ifndef FILEREADER_H
 #define FILEREADER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void TextParse(char* message,char* output);
 void hexConversion(char* hexMessage);
-
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/keyGeneration.h
+++ b/keyGeneration.h
@@ -2,6 +2,14 @@
 #ifndef KEYGENERATION_H
 #define KEYGENRERATION_H
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void keyGeneration();
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/tripleDESCBCDecryption.h
+++ b/tripleDESCBCDecryption.h
@@ -1,6 +1,14 @@
 #ifndef TRIPLEDESCBCDECRYPTION_H
 #define TRIPLEDESCBCDECRYPTION_H
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tripleDES_CBCDecryption(char *input,char* inputKey1,char* inputKey2,char* iv,int size);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/tripleDESCBCEncryption.h
+++ b/tripleDESCBCEncryption.h
@@ -1,6 +1,14 @@
 #ifndef TRIPLEDESCBCENCRYPTION_H
 #define TRIPLEDESCBCENCRYPTION_H
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tripleDES_CBCEncryption(char *input,char* inputKey1,char* inputKey2,char* iv,int size);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/tripleKeyDESCBCDecryption.h
+++ b/tripleKeyDESCBCDecryption.h
@@ -1,6 +1,15 @@
 #ifndef TRIPLEDESCBCDECRYPTION_H
 #define TRIPLEDESCBCDECRYPTION_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tripleKeyDES_CBCDecryption(char *input,char* inputKey1,char* inputKey2,char* inputKey3,char* iv,int size);
+
+#ifdef __cplusplus
+}
+#endif
+
 
 #endif

--- a/tripleKeyDESCBCEncryption.c
+++ b/tripleKeyDESCBCEncryption.c
@@ -22,6 +22,9 @@ void tripleKeyDES_CBCEncryption(char *input,char* inputKey1,char* inputKey2,char
  char output[8];
  char output2[8];
  char final[8];
+
+    int out_index=0;
+
  if(numBlocks == 1 && rem == 0) {
     for(k=0; k <8; k++){
       input[k] ^= iv[k];
@@ -31,7 +34,11 @@ void tripleKeyDES_CBCEncryption(char *input,char* inputKey1,char* inputKey2,char
     desEncryptionPer64_return(output2,inputKey3,prev);
 
     //COPY RESULT / jet
-     strncat(out,prev, sizeof(prev));
+//     strncat(out,prev, sizeof(prev));
+     for(k=0;k<8;k++){
+         out[out_index] = prev[k];
+         out_index++;
+     }
   }
 
   else if(rem != 0){
@@ -63,7 +70,11 @@ void tripleKeyDES_CBCEncryption(char *input,char* inputKey1,char* inputKey2,char
     desEncryptionPer64_return(output2,inputKey3,prev);
 
      //COPY RESULT / jet
-     strncat(out,prev, sizeof(prev));
+//     strncat(out,prev, sizeof(prev));
+     for(k=0;k<8;k++){
+         out[out_index] = prev[k];
+         out_index++;
+     }
    }
 
     free(newMessage);
@@ -92,7 +103,11 @@ void tripleKeyDES_CBCEncryption(char *input,char* inputKey1,char* inputKey2,char
     desEncryptionPer64_return(output2,inputKey3,prev);
 
      //COPY RESULT / jet
-     strncat(out,prev, sizeof(prev));
+//     strncat(out,prev, sizeof(prev));
+     for(k=0;k<8;k++){
+         out[out_index] = prev[k];
+         out_index++;
+     }
    }
 
 free(newMessage);

--- a/tripleKeyDESCBCEncryption.c
+++ b/tripleKeyDESCBCEncryption.c
@@ -8,10 +8,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-void tripleKeyDES_CBCEncryption(char *input,char* inputKey1,char* inputKey2,char* inputKey3,char* iv,int size);
+void tripleKeyDES_CBCEncryption(char *input,char* inputKey1,char* inputKey2,char* inputKey3,char* iv,int size ,char *out );
 
-void tripleKeyDES_CBCEncryption(char *input,char* inputKey1,char* inputKey2,char* inputKey3,char* iv,int size){
-
+void tripleKeyDES_CBCEncryption(char *input,char* inputKey1,char* inputKey2,char* inputKey3,char* iv,int size ,char *out ){
  char* newMessage = NULL;
  char(*messageBlocks)[8];
  int i,j,k;
@@ -30,6 +29,9 @@ void tripleKeyDES_CBCEncryption(char *input,char* inputKey1,char* inputKey2,char
     desEncryptionPer64_nullReturn(input,inputKey1,output);
     desDecryptionPer64_return(output,inputKey2,output2);
     desEncryptionPer64_return(output2,inputKey3,prev);
+
+    //COPY RESULT / jet
+     strncat(out,prev, sizeof(prev));
   }
 
   else if(rem != 0){
@@ -59,6 +61,9 @@ void tripleKeyDES_CBCEncryption(char *input,char* inputKey1,char* inputKey2,char
     desEncryptionPer64_nullReturn(temp,inputKey1,output);
     desDecryptionPer64_return(output,inputKey2,output2);
     desEncryptionPer64_return(output2,inputKey3,prev);
+
+     //COPY RESULT / jet
+     strncat(out,prev, sizeof(prev));
    }
 
     free(newMessage);
@@ -85,6 +90,9 @@ void tripleKeyDES_CBCEncryption(char *input,char* inputKey1,char* inputKey2,char
     desEncryptionPer64_nullReturn(temp,inputKey1,output);
     desDecryptionPer64_return(output,inputKey2,output2);
     desEncryptionPer64_return(output2,inputKey3,prev);
+
+     //COPY RESULT / jet
+     strncat(out,prev, sizeof(prev));
    }
 
 free(newMessage);

--- a/tripleKeyDESCBCEncryption.h
+++ b/tripleKeyDESCBCEncryption.h
@@ -1,6 +1,17 @@
 #ifndef TRIPLEDESCBCENCRYPTION_H
 #define TRIPLEDESCBCENCRYPTION_H
 
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tripleKeyDES_CBCEncryption(char *input,char* inputKey1,char* inputKey2,char* inputKey3,char* iv,int size ,char *out );
+
+#ifdef __cplusplus
+}
+#endif
+
 
 #endif

--- a/tripleKeyDESCBCEncryption.h
+++ b/tripleKeyDESCBCEncryption.h
@@ -1,6 +1,6 @@
 #ifndef TRIPLEDESCBCENCRYPTION_H
 #define TRIPLEDESCBCENCRYPTION_H
 
-void tripleKeyDES_CBCEncryption(char *input,char* inputKey1,char* inputKey2,char* inputKey3,char* iv,int size);
+void tripleKeyDES_CBCEncryption(char *input,char* inputKey1,char* inputKey2,char* inputKey3,char* iv,int size ,char *out );
 
 #endif


### PR DESCRIPTION
In C++ (Android  JNI ): if defined char[4] ,But use char[5...6...7..8] will overwrite other datas.